### PR TITLE
Keep dh_fixperms from cleaning up our mode changes

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -35,3 +35,5 @@ override_dh_install:
 	cd debian/base-files && chmod 2775 `cat ../2775-dirs`
 	cd debian/base-files && chmod 700 root
 
+# Keep fixperms from running and cleaning up our mode changes
+override_dh_fixperms:


### PR DESCRIPTION
dh_fixperms will try to clean everything up to reasonable permissions,
but we really want to keep the ones we made in override_dh_install. Add
an override for dh_fixperms to do nothing.

[endlessm/eos-shell#2718]
