### PR TITLE
Add gstreamer system plugin registry Xsession.d file

### DIFF
--- a/Makefile-integration.am
+++ b/Makefile-integration.am
@@ -56,3 +56,6 @@ EXTRA_DIST += \
 	$(srcdir)/src/lsb-release.in \
 	$(srcdir)/src/issue.in \
 	$(srcdir)/src/issue.net.in
+
+xsessionddir = $(sysconfdir)/X11/Xsession.d
+dist_xsessiond_DATA = Xsession.d/65gstreamer-plugin-registry

--- a/Xsession.d/65gstreamer-plugin-registry
+++ b/Xsession.d/65gstreamer-plugin-registry
@@ -1,0 +1,14 @@
+# Copyright 2015 Endless Mobile, Inc.
+# This file is sourced by Xsession(5), not executed.
+# Use gstreamer plugin system caches.
+
+arch=$(dpkg --print-architecture)
+
+# gstreamer-0.10 registry
+export GST_REGISTRY="/usr/share/gstreamer-0.10/registry.${arch}.bin"
+
+# gstreamer-1.0 registry
+export GST_REGISTRY_1_0="/usr/share/gstreamer-1.0/registry.${arch}.bin"
+
+# Don't try to update the registries at runtime.
+export GST_REGISTRY_UPDATE=no


### PR DESCRIPTION
In order to use the systemwide gstreamer plugin registries, a few
environment variables need to be set. This is hopefully temporary as a
more proper solution built into gstreamer will be worked on.

[endlessm/eos-shell#4835]