### PR TITLE
Add /var/lib/codecs to system library path

### DIFF
--- a/Makefile-integration.am
+++ b/Makefile-integration.am
@@ -56,3 +56,6 @@ EXTRA_DIST += \
 	$(srcdir)/src/lsb-release.in \
 	$(srcdir)/src/issue.in \
 	$(srcdir)/src/issue.net.in
+
+ldsoconfddir = $(sysconfdir)/ld.so.conf.d
+dist_ldsoconfd_DATA = ld.so.conf.d/50-codecs.conf

--- a/ld.so.conf.d/50-codecs.conf
+++ b/ld.so.conf.d/50-codecs.conf
@@ -1,0 +1,1 @@
+/var/lib/codecs


### PR DESCRIPTION
This allows installation of codec libraries outside of the core OS.

[endlessm/eos-shell#4864]