### PR TITLE
origins: add endless as an origin

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 package = base-files
 docdir = debian/base-files/usr/share/doc/$(package)
 
-VENDORFILE = ubuntu
+VENDORFILE = endless
 
 %:
 	dh $@ --with autoreconf


### PR DESCRIPTION
this is pending a decision to see if we want to merge our systemd packaging with debian/ubuntu.

... it is very annoying to have to split this trivial patch in 2 because we've decided to split the debian-master branch for no good reason.

Signed-off-by: Niv Sardi <xaiki@debian.org>