### PR TITLE
Don't set PATH in /etc/profile

### DIFF
--- a/share/profile
+++ b/share/profile
@@ -1,13 +1,6 @@
 # /etc/profile: system-wide .profile file for the Bourne shell (sh(1))
 # and Bourne compatible shells (bash(1), ksh(1), ash(1), ...).
 
-if [ "`id -u`" -eq 0 ]; then
-  PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-else
-  PATH="/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games"
-fi
-export PATH
-
 if [ "${PS1-}" ]; then
   if [ "${BASH-}" ] && [ "$BASH" != "/bin/sh" ]; then
     # The file bash.bashrc already sets the default PS1.


### PR DESCRIPTION
We don't want to prevent regular users from resolving paths in /sbin or
/usr/sbin, where reboot, poweroff, ifconfig etc live.

Let's let this be set by libpam-modules through /etc/environment.

https://phabricator.endlessm.com/T17924